### PR TITLE
Ensure tower-backend class files built for Java 8

### DIFF
--- a/tower-backend/build.gradle
+++ b/tower-backend/build.gradle
@@ -103,6 +103,8 @@ test.classpath += configurations.developmentOnly
 mainClassName = "io.seqera.tower.Application"
 tasks.withType(GroovyCompile) {
     groovyOptions.forkOptions.jvmArgs.add('-Dgroovy.parameters=true')
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8    
 }
 
 afterEvaluate {


### PR DESCRIPTION
Otherwise when built with a later compiler fails on `make run` with 

frontend_1  | 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
backend_1   | Exception in thread "main" java.lang.UnsupportedClassVersionError: io/seqera/tower/Application has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0